### PR TITLE
Release 0.1.0-beta.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ app.get(
 
 | fastify-lor-zod | Fastify | Zod | @fastify/swagger | fast-json-stringify | Node.js |
 |-----------------|---------|-----|------------------|---------------------|---------|
-| 0.1.0-beta.3    | >= 5.8  | >= 4.3 | >= 9.5 (optional) | >= 6.0 (optional, for `fastSerializerCompiler`) | >= 22 |
+| 0.1.0-beta.4    | >= 5.8  | >= 4.3 | >= 9.5 (optional) | >= 6.0 (optional, for `fastSerializerCompiler`) | >= 22 |
 
 ## Issues Addressed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-lor-zod",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "description": "A Fastify type provider integrating Zod for schema validation and type-safe route definitions",
   "type": "module",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary

- Add benchmark numbers to README (serialization + validation tables)
- Add `fast-json-stringify` to compatibility table
- Bump version to 0.1.0-beta.4