### PR TITLE
feat(serializer): auto-detect codecs at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Built with good vibes for Fastify v5 and Zod v4. Fixes [issues](https://github.c
 ## Why fastify-lor-zod?
 
 - **Zod v4 native** -- uses `safeEncode`, `toJSONSchema`, codecs, and registries directly
-- **Three serializer strategies** -- choose between robustness (codec support), validation-only, or raw speed
+- **Smart serializer** -- auto-detects codecs at compile time; falls back to `safeParse` for ~15% faster non-codec schemas
 - **Complete OpenAPI** -- all HTTP parts, nullable types, discriminated unions, recursive schemas, content types
 - **Type-safe end-to-end** -- `req.body`, `req.params`, `req.query`, `req.headers`, and `reply.send()` fully typed
-- **100% test coverage** -- 106 tests including snapshot parity with `fastify-type-provider-zod`
+- **100% test coverage** -- 121 tests including snapshot parity with `fastify-type-provider-zod`
 - **Why "Lor"?** -- [Son of Zod](https://dc.fandom.com/wiki/Lor-Zod), here to power your `fastify` schemas.
 
 ## Table of Contents
@@ -81,14 +81,14 @@ Three strategies for different trade-offs:
 
 | Compiler | Validates | Codecs | Speed | Use when |
 |----------|-----------|--------|-------|----------|
-| `serializerCompiler` | Yes | Yes | Baseline | You use `z.codec()` transforms |
-| `parseSerializerCompiler` | Yes | No | ~15% faster | You need validation but no codecs |
-| `fastSerializerCompiler` | No | No | Fastest | You trust your handlers |
+| `serializerCompiler` | Yes | Auto-detect | Fastest validating | **Recommended default** -- uses `safeParse` for plain schemas, `safeEncode` only when codecs are present |
+| `parseSerializerCompiler` | Yes | No | Same as above | Explicit opt-in to always use `safeParse` |
+| `fastSerializerCompiler` | No | No | Fastest overall | You trust your handlers and want maximum throughput |
 
 ```ts
 import {
-  serializerCompiler,         // default: z.safeEncode + JSON.stringify
-  parseSerializerCompiler,    // z.safeParse + JSON.stringify
+  serializerCompiler,         // default: auto-detects codecs, picks safeParse or safeEncode
+  parseSerializerCompiler,    // always z.safeParse + JSON.stringify
   fastSerializerCompiler,     // fast-json-stringify, no validation
 } from 'fastify-lor-zod';
 
@@ -103,19 +103,23 @@ Serialization throughput (ops/sec, higher is better):
 
 | Scenario | lor-zod | lor-zod (parse) | lor-zod (fast) | type-provider-zod | zod-openapi |
 |----------|---------|-----------------|----------------|-------------------|-------------|
-| Simple object | 245K | 305K | **670K** | 308K | 294K |
-| Nested (10 items) | 32K | 36K | **98K** | 36K | 34K |
-| Discriminated union | 433K | 540K | **703K** | 505K | 353K |
-| Recursive tree | 337K | 392K | **1.12M** | 384K | 462K |
+| Simple object | 305K | 305K | **624K** | 309K | 286K |
+| Simple object + date codec | 140K | Unsupported | **213K** | Unsupported | Unsupported |
+| Nested (10 items) | 34K | 35K | **78K** | 33K | 30K |
+| Nested + money codec | 30K | Unsupported | **87K** | Unsupported | Unsupported |
+| Discriminated union | **582K** | 541K | 652K | 457K | 341K |
+| Recursive tree | 393K | 372K | **1.21M** | 412K | 464K |
+
+For non-codec schemas, `serializerCompiler` auto-detects and matches `parseSerializerCompiler` speed. For codec schemas, it automatically uses `safeEncode`.
 
 Validation throughput (all libraries are within ~5% of each other):
 
 | Scenario | lor-zod | type-provider-zod | zod-openapi |
 |----------|---------|-------------------|-------------|
-| Simple object | 376K | 393K | 392K |
-| Nested (10 items) | 55K | 57K | 56K |
-| Discriminated union | 962K | 937K | 906K |
-| Recursive tree | 679K | 716K | 726K |
+| Simple object | 366K | 384K | 386K |
+| Nested (10 items) | 57K | 55K | 57K |
+| Discriminated union | 958K | 890K | 817K |
+| Recursive tree | 758K | 724K | 722K |
 
 > Measured on Apple M-series, Node.js 24, Zod 4.3.6. Run `pnpm bench` to reproduce.
 

--- a/bench/schemas.ts
+++ b/bench/schemas.ts
@@ -292,6 +292,84 @@ export const validTreeData: TreeNode = {
   ],
 };
 
+// --- Codec variants (Date ↔ ISO string) ---
+
+const dateCodec = z.codec(z.iso.datetime(), z.date(), {
+  decode: (iso: string) => new Date(iso),
+  encode: (date: Date) => date.toISOString(),
+});
+
+export const UserResponseWithCodec = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  email: z.string(),
+  age: z.number().int().nullable(),
+  role: z.enum(['admin', 'user', 'moderator']),
+  tags: z.array(z.string()),
+  address: AddressSchema.nullable(),
+  createdAt: dateCodec,
+  updatedAt: dateCodec,
+  posts: z.array(PostSchema),
+});
+
+export const validUserResponseDataWithCodec = {
+  ...validUserResponseData,
+  createdAt: new Date('2025-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2025-06-15T12:30:00.000Z'),
+};
+
+// Money codec: domain stores cents as integer, wire format is "$12.99" string
+const moneyCodec = z.codec(z.string(), z.number().int(), {
+  decode: (s: string) => Math.round(Number.parseFloat(s.replace('$', '')) * 100),
+  encode: (cents: number) => `$${(cents / 100).toFixed(2)}`,
+});
+
+export const OrderSchemaWithCodec = z.object({
+  orderId: z.string(),
+  userId: z.string(),
+  items: z.array(OrderItemSchema),
+  shipping: z.object({
+    address: OrderAddressSchema,
+    method: z.enum(['standard', 'express', 'overnight']),
+    cost: moneyCodec,
+    estimatedDays: z.number().int().positive(),
+    tracking: z.string().nullable(),
+  }),
+  billing: z.object({
+    address: OrderAddressSchema,
+    cardLast4: z.string().length(4),
+    expiryMonth: z.number().int().min(1).max(12),
+    expiryYear: z.number().int(),
+    cardBrand: z.enum(['visa', 'mastercard', 'amex', 'discover']),
+  }),
+  totals: z.object({
+    subtotal: moneyCodec,
+    tax: moneyCodec,
+    shipping: moneyCodec,
+    discount: moneyCodec,
+    total: moneyCodec,
+  }),
+  status: z.enum(['pending', 'confirmed', 'shipped', 'delivered', 'cancelled', 'refunded']),
+  notes: z.array(z.string()).optional(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const validOrderDataWithCodec = {
+  ...validOrderData,
+  shipping: {
+    ...validOrderData.shipping,
+    cost: 1299, // $12.99 in cents
+  },
+  totals: {
+    subtotal: 34990,
+    tax: 2800,
+    shipping: 1299,
+    discount: 3500,
+    total: 35589,
+  },
+};
+
 // --- Bench options (consistent across all benchmarks) ---
 
 export const benchOpts = {

--- a/bench/serialization.bench.ts
+++ b/bench/serialization.bench.ts
@@ -10,13 +10,17 @@ import {
 import {
   benchOpts,
   OrderSchema,
+  OrderSchemaWithCodec,
   PaymentResponse,
   TreeNodeSchema,
   UserResponse,
+  UserResponseWithCodec,
   validOrderData,
+  validOrderDataWithCodec,
   validPaymentSuccess,
   validTreeData,
   validUserResponseData,
+  validUserResponseDataWithCodec,
 } from './schemas.js';
 
 let _result: unknown;
@@ -33,7 +37,7 @@ const compile = (
     ]),
   );
 
-const providers = {
+const allProviders = {
   'fastify-lor-zod': lorZodSerializer,
   'fastify-lor-zod (parse)': lorZodParseSerializer,
   'fastify-lor-zod (fast)': lorZodFastSerializer,
@@ -41,13 +45,18 @@ const providers = {
   'fastify-zod-openapi': samchungySerializer,
 };
 
-// Pre-compile all serializers
-const userSerializers = compile(providers, UserResponse, '/users/42');
-const orderSerializers = compile(providers, OrderSchema, '/orders/1');
-const paymentSerializers = compile(providers, PaymentResponse, '/payments/1');
-const treeSerializers = compile(providers, TreeNodeSchema, '/tree');
+// Only auto-detect and fast support codecs; parse would fail validation on Date objects.
+const lorZodCodecProviders = {
+  'fastify-lor-zod': lorZodSerializer,
+  'fastify-lor-zod (fast)': lorZodFastSerializer,
+};
 
-describe('serialization — simple object (UserResponse)', () => {
+// --- Without codecs (auto-detect → safeParse) ---
+
+const userSerializers = compile(allProviders, UserResponse, '/users/42');
+const orderSerializers = compile(allProviders, OrderSchema, '/orders/1');
+
+describe('without codecs — simple object (UserResponse)', () => {
   for (const [name, serialize] of Object.entries(userSerializers)) {
     bench(
       name,
@@ -59,7 +68,7 @@ describe('serialization — simple object (UserResponse)', () => {
   }
 });
 
-describe('serialization — deeply nested (Order, 10 items)', () => {
+describe('without codecs — deeply nested (Order, 10 items)', () => {
   for (const [name, serialize] of Object.entries(orderSerializers)) {
     bench(
       name,
@@ -71,7 +80,42 @@ describe('serialization — deeply nested (Order, 10 items)', () => {
   }
 });
 
-describe('serialization — discriminated union (Payment)', () => {
+// --- With codecs (auto-detect → safeEncode) ---
+// Only lor-zod supports codecs; competitors would produce incorrect output.
+
+const userCodecSerializers = compile(lorZodCodecProviders, UserResponseWithCodec, '/users/42');
+const orderCodecSerializers = compile(lorZodCodecProviders, OrderSchemaWithCodec, '/orders/1');
+
+describe('with codecs — simple object (UserResponse + date codec)', () => {
+  for (const [name, serialize] of Object.entries(userCodecSerializers)) {
+    bench(
+      name,
+      () => {
+        _result = serialize(validUserResponseDataWithCodec);
+      },
+      benchOpts,
+    );
+  }
+});
+
+describe('with codecs — deeply nested (Order + money codec)', () => {
+  for (const [name, serialize] of Object.entries(orderCodecSerializers)) {
+    bench(
+      name,
+      () => {
+        _result = serialize(validOrderDataWithCodec);
+      },
+      benchOpts,
+    );
+  }
+});
+
+// --- Other schema shapes (without codecs) ---
+
+const paymentSerializers = compile(allProviders, PaymentResponse, '/payments/1');
+const treeSerializers = compile(allProviders, TreeNodeSchema, '/tree');
+
+describe('without codecs — discriminated union (Payment)', () => {
   for (const [name, serialize] of Object.entries(paymentSerializers)) {
     bench(
       name,
@@ -83,7 +127,7 @@ describe('serialization — discriminated union (Payment)', () => {
   }
 });
 
-describe('serialization — recursive tree (3 levels deep)', () => {
+describe('without codecs — recursive tree (3 levels deep)', () => {
   for (const [name, serialize] of Object.entries(treeSerializers)) {
     bench(
       name,

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -3,6 +3,7 @@ import type { FastifySerializerCompiler } from 'fastify/types/schema';
 import { z } from 'zod';
 
 import { ResponseSerializationError } from './errors.js';
+import { hasCodecInTree } from './utils/has-codec-in-tree.js';
 
 /**
  * Options for the serializer compiler factories.
@@ -25,11 +26,14 @@ export interface SerializerCompilerOptions {
 }
 
 /**
- * Creates a Fastify serializer compiler that uses Zod v4's `safeEncode` for response serialization.
+ * Creates a Fastify serializer compiler that auto-detects whether to use `safeEncode` or `safeParse`.
  *
- * This is the **recommended default**. For codec schemas, `safeEncode` runs the reverse
- * transform (domain type → wire format). For plain schemas, it validates the response matches
- * the schema. Throws {@link ResponseSerializationError} on failure.
+ * At compile time (when Fastify registers a route), inspects the schema tree for codec/pipe types.
+ * If codecs are found, uses `safeEncode` to run reverse transforms (domain type → wire format).
+ * If no codecs are found, uses `safeParse` for ~15% faster validation-only serialization.
+ *
+ * This is the **recommended default** — it gives the best of both worlds without manual selection.
+ * Throws {@link ResponseSerializationError} on failure.
  *
  * @param opts - Optional configuration (e.g. custom `JSON.stringify` replacer)
  * @returns A Fastify serializer compiler function
@@ -44,24 +48,30 @@ export interface SerializerCompilerOptions {
  */
 export const createSerializerCompiler =
   (opts: SerializerCompilerOptions = {}): FastifySerializerCompiler<z.ZodType> =>
-  ({ schema, method, url }) =>
-  (data: unknown): string => {
-    const result = z.safeEncode(schema, data);
-    if (!result.success) {
-      throw new ResponseSerializationError({
-        method,
-        url,
-        zodError: result.error,
-      });
-    }
-    return JSON.stringify(result.data, opts.replacer);
+  ({ schema, method, url }) => {
+    const useEncode = !schema?._zod?.def || hasCodecInTree(schema);
+    const validate = useEncode
+      ? (data: unknown) => z.safeEncode(schema, data)
+      : (data: unknown) => schema.safeParse(data);
+
+    return (data: unknown): string => {
+      const result = validate(data);
+      if (!result.success) {
+        throw new ResponseSerializationError({
+          method,
+          url,
+          zodError: result.error,
+        });
+      }
+      return JSON.stringify(result.data, opts.replacer);
+    };
   };
 
 /**
- * Default serializer compiler using `safeEncode` + `JSON.stringify`.
+ * Default serializer compiler with auto-detect codec support.
  *
- * Supports Zod v4 codecs (e.g. `Date` → ISO string) and validates responses
- * against the schema. This is the recommended serializer for most applications.
+ * Automatically uses `safeEncode` for schemas with codecs/pipes, and `safeParse`
+ * for plain schemas (~15% faster). This is the recommended serializer for most applications.
  *
  * @example
  * ```ts
@@ -71,11 +81,11 @@ export const createSerializerCompiler =
 export const serializerCompiler: FastifySerializerCompiler<z.ZodType> = createSerializerCompiler();
 
 /**
- * Creates a Fastify serializer compiler that uses Zod's `safeParse` for response validation.
+ * Creates a Fastify serializer compiler that always uses Zod's `safeParse` for response validation.
  *
- * Unlike {@link createSerializerCompiler} (which uses `safeEncode`), this skips the codec
- * encode step — ~10-15% faster but does **not** run reverse transforms for codec schemas.
- * Use this when you need response validation but don't use Zod codecs.
+ * Always uses `safeParse`, never `safeEncode` — does **not** run reverse transforms for codec schemas.
+ * For most use cases, prefer {@link createSerializerCompiler} which auto-detects codecs and
+ * uses `safeParse` for non-codec schemas automatically.
  *
  * Throws {@link ResponseSerializationError} on validation failure.
  *
@@ -105,8 +115,8 @@ export const createParseSerializerCompiler =
 /**
  * Default validating serializer using `safeParse` + `JSON.stringify`.
  *
- * Validates responses but skips codec encoding. ~10-15% faster than
- * {@link serializerCompiler} when codecs are not used.
+ * Always uses `safeParse`, skips codec encoding. Prefer {@link serializerCompiler}
+ * which auto-detects and matches this speed for non-codec schemas.
  *
  * @example
  * ```ts

--- a/src/utils/has-codec-in-tree.test.ts
+++ b/src/utils/has-codec-in-tree.test.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+
+import { hasCodecInTree } from './has-codec-in-tree.js';
+
+const dateCodec = z.codec(z.iso.datetime(), z.date(), {
+  decode: (s: string) => new Date(s),
+  encode: (d: Date) => d.toISOString(),
+});
+
+describe('hasCodecInTree', () => {
+  it('returns false for plain object schema', () => {
+    expect(hasCodecInTree(z.object({ name: z.string(), age: z.number() }))).toBe(false);
+  });
+
+  it('returns true for schema with transform (pipe in Zod v4)', () => {
+    expect(hasCodecInTree(z.string().transform((s) => s.toUpperCase()))).toBe(true);
+  });
+
+  it('returns false for lazy schema without codec', () => {
+    expect(hasCodecInTree(z.lazy(() => z.string()))).toBe(false);
+  });
+
+  it('returns true for object with codec field', () => {
+    expect(hasCodecInTree(z.object({ d: dateCodec }))).toBe(true);
+  });
+
+  it('returns true for array of codec elements', () => {
+    expect(hasCodecInTree(z.array(dateCodec))).toBe(true);
+  });
+
+  it('returns true for optional codec', () => {
+    expect(hasCodecInTree(z.optional(dateCodec))).toBe(true);
+  });
+
+  it('returns true for nullable codec', () => {
+    expect(hasCodecInTree(z.nullable(dateCodec))).toBe(true);
+  });
+
+  it('returns true for union with codec variant', () => {
+    expect(hasCodecInTree(z.union([z.string(), dateCodec]))).toBe(true);
+  });
+
+  it('returns true for deeply nested codec', () => {
+    expect(hasCodecInTree(z.object({ a: z.object({ b: z.object({ c: dateCodec }) }) }))).toBe(true);
+  });
+
+  it('returns true for tuple with codec element', () => {
+    expect(hasCodecInTree(z.tuple([z.string(), dateCodec]))).toBe(true);
+  });
+
+  it('returns true for record with codec value', () => {
+    expect(hasCodecInTree(z.record(z.string(), dateCodec))).toBe(true);
+  });
+
+  it('returns true for lazy schema with codec', () => {
+    expect(hasCodecInTree(z.lazy(() => z.object({ d: dateCodec })))).toBe(true);
+  });
+
+  it('returns false for enum schema (options are primitives, not schemas)', () => {
+    expect(hasCodecInTree(z.enum(['a', 'b', 'c']))).toBe(false);
+  });
+
+  it('returns false for non-ZodType input', () => {
+    expect(hasCodecInTree({ description: 'not a schema' } as unknown as z.ZodType)).toBe(false);
+  });
+
+  it('handles circular schema without stack overflow', () => {
+    type Node = { value: string; child?: Node };
+    const nodeSchema: z.ZodType<Node> = z.lazy(() =>
+      z.object({ value: z.string(), child: nodeSchema.optional() }),
+    );
+    expect(hasCodecInTree(nodeSchema)).toBe(false);
+  });
+});

--- a/src/utils/has-codec-in-tree.ts
+++ b/src/utils/has-codec-in-tree.ts
@@ -1,0 +1,77 @@
+import type { z } from 'zod';
+
+/** Duck-type check: is this value a ZodType instance? */
+const isZodType = (v: unknown): v is z.ZodType => v != null && typeof v === 'object' && '_zod' in v;
+
+/**
+ * Safely read a property from an object, returning only object values.
+ * Zod def properties are always null, ZodType, array, or plain object — never primitives.
+ */
+const get = (obj: object, key: string): object | undefined => {
+  if (!(key in obj)) return undefined;
+  const v: unknown = (obj as never)[key];
+  return v != null && typeof v === 'object' ? v : undefined;
+};
+
+/** Push a single schema, spread an array, or spread a plain object's values into `out`. */
+const visitNode = (v: object | undefined, out: unknown[]) => {
+  if (v == null) return;
+  if (isZodType(v)) out.push(v);
+  else if (Array.isArray(v)) out.push(...v);
+  else out.push(...Object.values(v));
+};
+
+/** Gather all potential child values from a Zod schema def. */
+const traverseTree = (schema: z.ZodType): unknown[] => {
+  const def = schema._zod.def;
+  const out: unknown[] = [];
+
+  // object → shape values, array → element, tuple → items + rest
+  visitNode(get(def, 'shape'), out);
+  visitNode(get(def, 'element'), out);
+  visitNode(get(def, 'items'), out);
+  visitNode(get(def, 'rest'), out);
+
+  // record/map → keyType + valueType, set → valueType
+  visitNode(get(def, 'keyType'), out);
+  visitNode(get(def, 'valueType'), out);
+
+  // intersection → left + right, union → options
+  visitNode(get(def, 'left'), out);
+  visitNode(get(def, 'right'), out);
+  visitNode(get(def, 'options'), out);
+
+  // optional/nullable/default/catch/readonly/… → innerType
+  visitNode(get(def, 'innerType'), out);
+
+  // lazy → cached innerType on _zod internals
+  if (def.type === 'lazy') visitNode(get(schema._zod, 'innerType'), out);
+
+  return out;
+};
+
+/**
+ * Checks whether a Zod schema tree contains any pipe/codec types
+ * that require `safeEncode` for correct serialization.
+ *
+ * Called once per route at compile time (when Fastify registers the route),
+ * not per request. Uses a `WeakSet` to handle circular schemas (e.g. lazy self-refs).
+ *
+ * @param schema - The Zod schema to inspect
+ * @param seen - Internal set for cycle detection
+ * @returns `true` if the schema tree contains a pipe or codec
+ */
+export const hasCodecInTree = (
+  schema: z.ZodType,
+  seen: WeakSet<z.ZodType> = new WeakSet<z.ZodType>(),
+): boolean => {
+  if (!schema?._zod?.def) return false;
+  if (seen.has(schema)) return false;
+  seen.add(schema);
+
+  if (schema._zod.def.type === 'pipe') return true;
+
+  return traverseTree(schema)
+    .filter(isZodType)
+    .some((child) => hasCodecInTree(child, seen));
+};

--- a/test-spec.md
+++ b/test-spec.md
@@ -35,6 +35,24 @@ Three serializer compilers: `safeEncode` (default, codec support), `safeParse` (
 - [x] serializer uses encode for codec schemas
 - [x] Custom serializer replacer modifies JSON.stringify output
 
+## Auto-detect codec (`has-codec-in-tree.test.ts`) — 15 tests
+
+- [x] returns false for plain object schema
+- [x] returns true for schema with transform (pipe in Zod v4)
+- [x] returns false for lazy schema without codec
+- [x] returns true for object with codec field
+- [x] returns true for array of codec elements
+- [x] returns true for optional codec
+- [x] returns true for nullable codec
+- [x] returns true for union with codec variant
+- [x] returns true for deeply nested codec
+- [x] returns true for tuple with codec element
+- [x] returns true for record with codec value
+- [x] returns true for lazy schema with codec
+- [x] returns false for enum schema (options are primitives, not schemas)
+- [x] returns false for non-ZodType input
+- [x] handles circular schema without stack overflow
+
 ## Error Handling (`errors.test.ts`) — 2 tests
 
 - [x] Returns 400 with structured error on body validation error (method, url, validation details)
@@ -139,4 +157,4 @@ Byte-identical snapshot output with turkerdev/fastify-type-provider-zod `fastify
 
 ---
 
-**Total: 106 tests across 7 test files**
+**Total: 121 tests across 8 test files**


### PR DESCRIPTION
## Summary

- `serializerCompiler` now inspects the schema tree at route registration and picks `safeParse` (fast) or `safeEncode` (codec) automatically
- Non-codec schemas no longer pay the ~15% `safeEncode` overhead
- Added `hasCodecInTree` utility in `src/utils/` — walks object/array/tuple/record/union/intersection/optional/nullable/lazy/etc.
- 15 new unit tests for codec detection, 121 total (100% coverage)
- Benchmarks restructured to show with/without codec scenarios
- README and TSDoc updated to reflect auto-detect behavior

## Test plan

- [ ] `pnpm test:coverage` — 121 tests, 100% coverage
- [ ] `pnpm typecheck && pnpm check && pnpm knip` — clean
- [ ] `pnpm bench` — auto-detect matches `parseSerializerCompiler` speed for non-codec schemas
- [ ] Codec schemas still encode correctly (Date→ISO, cents→"$12.99")