### PR TITLE
fix(release): add repo to changelog-github config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.3/schema.json",
-  "changelog": "@changesets/changelog-github",
+  "changelog": ["@changesets/changelog-github", { "repo": "drudolf/fastify-lor-zod" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
Fixes the version workflow crash — `@changesets/changelog-github` requires a `repo` field in the config.