### PR TITLE
ci: skip CI for changeset version PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   ci:
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     container: node:24-alpine
     env:


### PR DESCRIPTION
Skips the CI job when the PR comes from `changeset-release/main`. GitHub treats a skipped job as neutral, satisfying required checks without needing a PAT.