### PR TITLE
ci: remove redundant skip condition for version PR branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   ci:
-    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     container: node:24-alpine
     env:


### PR DESCRIPTION
## Summary

- Removes the `if: github.head_ref != 'changeset-release/main'` job condition added in #18
- That condition was a workaround attempt; the real fix (posting a passing commit status from `version.yml`) landed in #19
- CI never ran on `changeset-release/main` to begin with (GitHub Actions GITHUB_TOKEN limitation), so the skip condition was a no-op

## Test plan
- [ ] CI passes on this PR
- [ ] Merge and confirm version PR flow still works on the next changeset cycle