### PR TITLE
fix(types): make response fields with .default() optional in handler return type

### DIFF
--- a/.changeset/fix-serializer-type-defaults.md
+++ b/.changeset/fix-serializer-type-defaults.md
@@ -1,0 +1,14 @@
+---
+'fastify-lor-zod': minor
+---
+
+Fix serializer type provider to make `.default()` response fields optional
+
+`FastifyLorZodTypeProvider` previously mapped the serializer to `z.output`, which
+made fields with `.default()` appear as required in handler return types. Handlers
+could not omit defaulted fields without a type error, defeating the purpose of `.default()`.
+
+The serializer now uses `SerializerType<T>`: `z.input` when output is a subtype of input
+(plain schemas and `.default()` schemas — making defaulted fields optional), falling back
+to `z.output` for codec schemas (where `Date` diverges from `string`) and `z.preprocess`
+schemas (where input is `unknown`).

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -426,20 +426,20 @@ describe('type inference', () => {
   it('infers output type for schemas with defaults', async () => {
     const app = buildApp();
 
-    app.post(
+    app.get(
       '/',
       {
         schema: {
-          body: z.object({
-            name: z.string(),
-            role: z.string().default('user'),
-          }),
+          response: {
+            200: z.object({ name: z.string(), role: z.string().default('user') }),
+          },
         },
       },
-      (req) => {
-        // After validation, default is applied — role is always string
-        expectTypeOf(req.body).toEqualTypeOf<{ name: string; role: string }>();
-        return req.body;
+      (_req, reply) => {
+        // role has a default — reply.send should accept it as optional
+        expectTypeOf(reply.send)
+          .parameter(0)
+          .toExtend<{ name: string; role?: string | undefined } | undefined>();
       },
     );
 
@@ -453,15 +453,35 @@ describe('type inference', () => {
       '/',
       {
         schema: {
-          querystring: z.object({
-            ids: z.string().transform((s) => s.split(',')),
-          }),
+          response: {
+            200: z.object({ id: z.string().transform((s) => parseInt(s, 10)) }),
+          },
         },
       },
-      (req) => {
-        // After transform, ids is string[]
-        expectTypeOf(req.query).toEqualTypeOf<{ ids: string[] }>();
-        return { ids: req.query.ids };
+      (_req, reply) => {
+        // transform produces number — reply.send should accept number for id
+        expectTypeOf(reply.send).parameter(0).toExtend<{ id: number }>();
+      },
+    );
+
+    await app.ready();
+  });
+
+  it('Infers output type for response schemas with preprocess', async () => {
+    const app = buildApp();
+
+    app.get(
+      '/',
+      {
+        schema: {
+          response: {
+            200: z.preprocess((v) => String(v), z.string()),
+          },
+        },
+      },
+      (_req, reply) => {
+        // preprocess has z.input = unknown — SerializerType must resolve to z.output = string, not unknown
+        expectTypeOf(reply.send).parameter(0).toExtend<string | undefined>();
       },
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,12 @@ import type { z } from 'zod';
 /**
  * Fastify type provider that integrates Zod v4 for schema validation and serialization.
  *
- * Both `validator` and `serializer` map to `z.output`, so request handlers receive
- * the validated/transformed output type, and `reply.send()` accepts the domain type
- * (the serializer handles encoding to wire format).
+ * The `validator` maps to `z.output` so request handlers receive the validated/transformed
+ * output type. The `serializer` uses `z.input` when `output extends input` (plain schemas
+ * and schemas with `.default()`), making defaulted fields optional in handler return types —
+ * returning `undefined` for such a field lets Zod apply the default during serialization.
+ * For codec schemas where `output` diverges from `input` (e.g. `Date` vs `string`), the
+ * serializer maps to `z.output` so handlers return the domain type for encoding.
  *
  * @example
  * ```ts
@@ -28,9 +31,24 @@ import type { z } from 'zod';
  * //               ^ typed as number
  * ```
  */
+/**
+ * Resolves the handler return type for a response schema.
+ *
+ * Uses `z.input<T>` when output is a subtype of input and input is not `unknown`
+ * (plain schemas and schemas with `.default()` — makes defaulted fields optional).
+ * Falls back to `z.output<T>` for codec schemas (where `Date` diverges from `string`)
+ * and for `z.preprocess` schemas (where input is `unknown`).
+ */
+type SerializerType<T extends z.ZodType> =
+  z.output<T> extends z.input<T>
+    ? unknown extends z.input<T>
+      ? z.output<T>
+      : z.input<T>
+    : z.output<T>;
+
 export interface FastifyLorZodTypeProvider extends FastifyTypeProvider {
   readonly validator: this['schema'] extends z.ZodType ? z.output<this['schema']> : unknown;
-  readonly serializer: this['schema'] extends z.ZodType ? z.output<this['schema']> : unknown;
+  readonly serializer: this['schema'] extends z.ZodType ? SerializerType<this['schema']> : unknown;
 }
 
 export { RequestValidationError, ResponseSerializationError } from './errors.js';

--- a/src/serializer.test.ts
+++ b/src/serializer.test.ts
@@ -205,3 +205,28 @@ describe('serializer — safeEncode only', () => {
     expect(body.secret).toBe('[REDACTED]');
   });
 });
+
+describe.each(validatingSerializers)('serializer — $name — default values', ({ compiler }) => {
+  it('applies default value for omitted field in response schema', async () => {
+    const app = buildApp(compiler);
+    app.get(
+      '/',
+      {
+        schema: {
+          response: {
+            200: z.object({
+              name: z.string(),
+              role: z.string().default('user'),
+            }),
+          },
+        },
+      },
+      () => ({ name: 'Alice' }),
+    );
+
+    const response = await app.inject({ method: 'GET', url: '/' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ name: 'Alice', role: 'user' });
+  });
+});

--- a/test-spec.md
+++ b/test-spec.md
@@ -12,7 +12,7 @@
 - [x] Uses undefined as httpPart fallback when not provided
 - [x] Headers can be modified after validation (#209)
 
-## Serialization (`serializer.test.ts`) — 23 tests
+## Serialization (`serializer.test.ts`) — 25 tests
 
 Three serializer compilers: `safeEncode` (default, codec support), `safeParse` (validation, no codecs), `fast` (fast-json-stringify, no validation).
 
@@ -29,6 +29,10 @@ Three serializer compilers: `safeEncode` (default, codec support), `safeParse` (
 - [x] Throws 500 on non-empty response with 204 schema
 - [x] Returns 500 on incorrect string response
 - [x] Returns 500 on incorrect object response
+
+### Default values — safeEncode + safeParse only (×2 = 2 tests)
+
+- [x] applies default value for omitted field in response schema
 
 ### safeEncode only — 2 tests
 
@@ -140,7 +144,7 @@ Byte-identical snapshot output with turkerdev/fastify-type-provider-zod `fastify
 - [x] Handles additionalProperties recursively for OAS 3.0
 - [x] throws on unsupported OpenAPI version
 
-## Integration & Type Inference (`index.test.ts`) — 12 tests
+## Integration & Type Inference (`index.test.ts`) — 13 tests
 
 - [x] Boots, handles requests, and produces a valid OpenAPI spec
 - [x] Uses Zod codec encode for response serialization
@@ -154,6 +158,7 @@ Byte-identical snapshot output with turkerdev/fastify-type-provider-zod `fastify
 - [x] Infers response type for reply.send()
 - [x] Infers output type for schemas with defaults
 - [x] Infers output type for schemas with transforms
+- [x] Infers output type for response schemas with preprocess
 
 ## OpenAPI Metaschema Validation (`openapi-metaschema.test.ts`) — 2 tests
 


### PR DESCRIPTION
## Summary

- `FastifyLorZodTypeProvider` serializer previously mapped to `z.output`, making fields with `.default()` appear as **required** in handler return types — preventing valid usage of `.default()` in response schemas
- Introduces `SerializerType<T>`: uses `z.input` when output is a subtype of input (plain schemas and `.default()` fields become optional), falls back to `z.output` for codecs (`Date` vs `string`) and `z.preprocess` schemas (`unknown` input)
- Adds regression tests for defaults, transforms, and preprocess response schemas via `reply.send` type assertions

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:coverage` — 126 tests, 100% coverage
- [x] `pnpm check` — clean
- [x] `pnpm knip` — clean