### PR TITLE
chore: add changeset for CJS output

### DIFF
--- a/.changeset/cjs-output.md
+++ b/.changeset/cjs-output.md
@@ -1,0 +1,5 @@
+---
+"fastify-lor-zod": minor
+---
+
+Add CommonJS output alongside ESM. The package now ships both `dist/index.js` (ESM) and `dist/index.cjs` (CJS), with `"require"` and `"import"` conditions in the `exports` field and a `"main"` field for legacy consumers.


### PR DESCRIPTION
Adds the missing changeset for the CJS output landed in #25. Marked as `minor` since it adds a new distribution format for existing consumers.