### PR TITLE
feat(validator): auto-coerce single values to arrays for array schemas (#151)

### DIFF
--- a/.changeset/feat-querystring-single-to-array.md
+++ b/.changeset/feat-querystring-single-to-array.md
@@ -1,0 +1,11 @@
+---
+'fastify-lor-zod': minor
+---
+
+Auto-coerce single querystring/params/headers values into arrays when the schema expects `z.array(...)` (#151).
+
+Fastify's default querystring parser returns `"a"` for `?tags=a` but `["a","b"]` for `?tags=a&tags=b`. Users writing `z.array(z.string())` hit a 400 on the single-value case. The validator now retries failed parses, wrapping non-array values in `[value]` at paths where Zod reported `expected: 'array'`. Uses Zod's own issue codes as the oracle — no schema tree walking, so wrapper variants (`.optional()`, `.nullable()`, `.default()`, `.min()`) are handled uniformly.
+
+Applied only to `querystring`, `params`, and `headers`. Body is unaffected — JSON payloads are never ambiguous. `z.tuple` and `z.set` are deliberately excluded; they emit different `expected` values.
+
+**Behavior change:** requests that previously returned 400 for single-value array querystrings now succeed. If any downstream code relied on that 400, it will need updating.

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -232,4 +232,236 @@ describe('validator', () => {
       expect(response.headers['x-response-id']).toBe('abc-123');
     });
   });
+  describe('single-to-array coercion (#151)', () => {
+    it('Coerces single querystring value into array for z.array schema (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: { querystring: z.object({ tags: z.array(z.string()) }) },
+        },
+        (req) => ({ tags: req.query.tags }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?tags=apple' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ tags: ['apple'] });
+    });
+
+    it('Already-array querystring passes through unchanged (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: { querystring: z.object({ tags: z.array(z.string()) }) },
+        },
+        (req) => ({ tags: req.query.tags }),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/?tags=apple&tags=peach',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ tags: ['apple', 'peach'] });
+    });
+
+    it('Coerces single value with optional array schema (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: { querystring: z.object({ tags: z.array(z.string()).optional() }) },
+        },
+        (req) => ({ tags: req.query.tags ?? null }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?tags=apple' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ tags: ['apple'] });
+    });
+
+    it('Coerces single value with nullable array schema (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: { querystring: z.object({ tags: z.array(z.string()).nullable() }) },
+        },
+        (req) => ({ tags: req.query.tags }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?tags=apple' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ tags: ['apple'] });
+    });
+
+    it('Coerces single value with defaulted array schema (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: { querystring: z.object({ tags: z.array(z.string()).default([]) }) },
+        },
+        (req) => ({ tags: req.query.tags }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?tags=apple' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ tags: ['apple'] });
+    });
+
+    it('Coerces single value with refined array min length (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: { querystring: z.object({ tags: z.array(z.string()).min(1) }) },
+        },
+        (req) => ({ tags: req.query.tags }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?tags=apple' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ tags: ['apple'] });
+    });
+
+    it('Coerces single value through element coercion (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: { querystring: z.object({ counts: z.array(z.coerce.number()) }) },
+        },
+        (req) => ({ counts: req.query.counts }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?counts=42' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ counts: [42] });
+    });
+
+    it('Coerces multiple single-value array fields in one request (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: {
+            querystring: z.object({
+              tags: z.array(z.string()),
+              ids: z.array(z.string()),
+            }),
+          },
+        },
+        (req) => ({ tags: req.query.tags, ids: req.query.ids }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?tags=a&ids=b' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ tags: ['a'], ids: ['b'] });
+    });
+
+    it('Does not coerce when schema expects non-array (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: { querystring: z.object({ name: z.string() }) },
+        },
+        (req) => ({ name: req.query.name }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?name=alice' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ name: 'alice' });
+    });
+
+    it('Does not coerce tuple single values (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: {
+            querystring: z.object({ pair: z.tuple([z.string(), z.string()]) }),
+          },
+        },
+        (req) => ({ pair: req.query.pair }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?pair=a' });
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('Coerces single header value into array (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: {
+            headers: z.object({ 'x-roles': z.array(z.string()) }).loose(),
+          },
+        },
+        (req) => ({ roles: req.headers['x-roles'] }),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/',
+        headers: { 'x-roles': 'admin' },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ roles: ['admin'] });
+    });
+
+    it('Coerces single params value into array (#151)', async () => {
+      // Params validation runs on the parsed object; wildcard routes can expose arrays.
+      // Direct compiler test proves the httpPart branch is wired correctly.
+      const validate = validatorCompiler({
+        schema: z.object({ ids: z.array(z.string()) }),
+        httpPart: 'params',
+        url: '/',
+        method: 'GET',
+      });
+
+      const result = validate({ ids: 'only-one' });
+      expect(result).toEqual({ value: { ids: ['only-one'] } });
+    });
+
+    it('Does not coerce body single value to array (#151)', async () => {
+      const app = buildApp();
+      app.post(
+        '/',
+        {
+          schema: { body: z.object({ tags: z.array(z.string()) }) },
+        },
+        (req) => ({ tags: req.body.tags }),
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/',
+        payload: { tags: 'apple' },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('Does not false-coerce when union matches non-array branch (#151)', async () => {
+      const app = buildApp();
+      app.get(
+        '/',
+        {
+          schema: {
+            querystring: z.object({
+              value: z.union([z.array(z.string()), z.string()]),
+            }),
+          },
+        },
+        (req) => ({ value: req.query.value }),
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/?value=apple' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ value: 'apple' });
+    });
+  });
 });

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -3,6 +3,56 @@ import type { z } from 'zod';
 
 import { mapIssueToValidationError } from './error.js';
 
+/** HTTP parts where Fastify's parser returns a single string for single-valued inputs (#151). */
+const ARRAYABLE_PARTS = new Set(['querystring', 'params', 'headers']);
+
+/**
+ * Coerces single-value request inputs into arrays when the schema expects an array (#151).
+ *
+ * Fastify's default querystring parser returns `"x"` for `?tags=x` but `["x","y"]` for
+ * `?tags=x&tags=y`. Users writing `z.array(z.string())` hit a 400 on the single-value case.
+ * This helper retries with single values wrapped in arrays, guided by Zod's own issue
+ * codes — no schema introspection required.
+ *
+ * Algorithm: run `safeParse`. If it fails, find issues with `expected: 'array'` at a
+ * top-level property path, wrap the non-array input at each such key in `[value]`, and
+ * retry once. The second `safeParse` result (success or failure) is final. Only length-1
+ * paths are patched — Fastify's default parser produces flat objects, so deeper paths
+ * can't originate from real requests. `z.tuple` / `z.set` are deliberately excluded —
+ * they report different `expected` values.
+ *
+ * Scope: coercion applies only to array fields **inside** an object schema. A root-level
+ * `z.array(...)` schema (path length 0) is not coerced — unreachable in practice, since
+ * Fastify's default parser always yields an object for querystring/params/headers. Unions
+ * like `z.union([z.array(...), z.string()])` don't false-coerce either: if any branch
+ * matches the incoming value, the first `safeParse` succeeds and coercion never runs.
+ */
+const coerceSingleToArray = (
+  schema: z.ZodType,
+  data: unknown,
+): ReturnType<z.ZodType['safeParse']> => {
+  const first = schema.safeParse(data);
+  if (first.success) return first;
+
+  const arrayIssues = first.error.issues.filter(
+    (issue) =>
+      issue.code === 'invalid_type' &&
+      'expected' in issue &&
+      issue.expected === 'array' &&
+      issue.path.length === 1,
+  );
+  if (arrayIssues.length === 0) return first;
+
+  const source = data as Record<PropertyKey, unknown>;
+  const patched: Record<PropertyKey, unknown> = { ...source };
+  for (const issue of arrayIssues) {
+    const key = issue.path[0] as PropertyKey;
+    patched[key] = [source[key]];
+  }
+
+  return schema.safeParse(patched);
+};
+
 /**
  * Fastify validator compiler that uses Zod's `safeParse` for request validation.
  *
@@ -10,6 +60,10 @@ import { mapIssueToValidationError } from './error.js';
  * `{ value }` with the parsed data. On failure augments the `ZodError` with
  * `input` and a Fastify-native `validation` array, then returns it. Fastify adds
  * `validationContext` and `statusCode` downstream via `wrapValidationError`.
+ *
+ * For `querystring`, `params`, and `headers`, single-value inputs are automatically
+ * coerced into arrays when the schema expects `z.array(...)` — covers the `?tag=a`
+ * vs `?tag=a&tag=b` asymmetry in Fastify's default parser (#151).
  *
  * Use {@link isRequestValidationError} in your error handler to detect and access
  * the structured validation details.
@@ -26,7 +80,10 @@ import { mapIssueToValidationError } from './error.js';
 export const validatorCompiler: FastifySchemaCompiler<z.ZodType> =
   ({ schema, httpPart }) =>
   (data: unknown) => {
-    const result = schema.safeParse(data);
+    const result =
+      httpPart !== undefined && ARRAYABLE_PARTS.has(httpPart)
+        ? coerceSingleToArray(schema, data)
+        : schema.safeParse(data);
     if (!result.success) {
       const error = result.error as z.ZodError & {
         input?: unknown;

--- a/test-spec.md
+++ b/test-spec.md
@@ -1,6 +1,6 @@
 # Test Specification
 
-## Request Validation (`validator/validator.test.ts`) — 10 tests
+## Request Validation (`validator/validator.test.ts`) — 24 tests
 
 - [x] Accepts valid querystring parameters
 - [x] Accepts requests on routes without schema
@@ -12,6 +12,20 @@
 - [x] Uses undefined as httpPart fallback when not provided
 - [x] Headers can be modified after validation (#209)
 - [x] Exposes original input on validation error
+- [x] Coerces single querystring value into array for z.array schema (#151)
+- [x] Already-array querystring passes through unchanged (#151)
+- [x] Coerces single value with optional array schema (#151)
+- [x] Coerces single value with nullable array schema (#151)
+- [x] Coerces single value with defaulted array schema (#151)
+- [x] Coerces single value with refined array min length (#151)
+- [x] Coerces single value through element coercion (#151)
+- [x] Coerces multiple single-value array fields in one request (#151)
+- [x] Does not coerce when schema expects non-array (#151)
+- [x] Does not coerce tuple single values (#151)
+- [x] Coerces single header value into array (#151)
+- [x] Coerces single params value into array (#151)
+- [x] Does not coerce body single value to array (#151)
+- [x] Does not false-coerce when union matches non-array branch (#151)
 
 ## Serialization (`serializer/serializer.test.ts`) — 36 tests
 
@@ -229,4 +243,4 @@ Byte-identical snapshot output with turkerdev/fastify-type-provider-zod `fastify
 - [x] Generated OAS 3.0.3 spec passes official metaschema validation
 - [x] Generated OAS 3.1.0 spec passes official metaschema validation
 
-**Total: 167 spec entries, 184 tests across 10 test files**
+**Total: 168 spec entries, 185 tests across 10 test files**


### PR DESCRIPTION
## Summary

Fixes [turkerdev/fastify-type-provider-zod#151](https://github.com/turkerdev/fastify-type-provider-zod/issues/151). Fastify's default querystring parser returns `"x"` for `?tags=x` but `["x","y"]` for `?tags=x&tags=y`. Users writing `z.array(z.string())` hit a 400 on the single-value case.

The validator now retries failed parses, wrapping non-array values in `[value]` at paths where Zod reported `expected: 'array'`. Applied only to `querystring`, `params`, and `headers` — body is unaffected since JSON payloads are never ambiguous.

## Approach

Uses Zod's own issue codes as the oracle — no schema tree walking. Wrapper variants (`.optional()`, `.nullable()`, `.default()`, `.min()`) are handled uniformly because they all report `expected: 'array'` on a non-array input.

`z.tuple` and `z.set` are deliberately excluded; they emit different `expected` values. Union schemas with a non-array branch don't false-coerce — if any branch matches, the first `safeParse` succeeds and coercion never runs.

## Behavior change (minor bump)

Requests that previously returned 400 for single-value array querystrings now succeed. If any downstream code relied on that 400, it will need updating.

## Test plan

- [x] 14 new tests covering single→array, multi passthrough, optional/nullable/defaulted/refined arrays, element coercion, multiple fields, tuple exclusion, header/params coercion, body unaffected, union non-false-coercion
- [x] `pnpm test:coverage` — 198 tests pass, 100% coverage
- [x] `pnpm check`, `pnpm typecheck`, `pnpm knip`, `pnpm test:spec-check` all pass